### PR TITLE
Ignore geosearch if it fails to load, show message it's unavailable

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -135,10 +135,13 @@ USGS Bar
                 <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
                 <h4 class="modal-title">Find Location</h4>
             </div>
-            <div class="modal-body">
+            <div id="geosearchUnavailable">Geosearch Currently Unavailable</div>
+
+            <div class="modal-body" id="geosearchModalBody">
                 <div class="form-group">
                     <div id="geosearch"></div>
                 </div>
+				
                 <form id="geosearch-form" class="form-inline">
                     <!--<div class="checkbox">
                         <label>

--- a/src/scripts/core.js
+++ b/src/scripts/core.js
@@ -5162,53 +5162,59 @@ require([
 
 
     // create search_api widget in element "geosearch"
-    search_api.create( "geosearch", {
-        on_result: function(o) {
-            // what to do when a location is found
-            // o.result is geojson point feature of location with properties
+	if(typeof search_api !== 'undefined'){
+		search_api.create( "geosearch", {
+			on_result: function(o) {
+				// what to do when a location is found
+				// o.result is geojson point feature of location with properties
 
-            // zoom to location
-            require(["esri/geometry/Extent"], function(Extent) {
-                var noExtents = ["GNIS_MAJOR", "GNIS_MINOR", "ZIPCODE", "AREACODE"];
-                var noExtentCheck = noExtents.indexOf(o.result.properties["Source"])
-                if (noExtentCheck == -1) {
-                    map.setExtent(
-                        new esri.geometry.Extent({
-                            xmin: o.result.properties.LonMin,
-                            ymin: o.result.properties.LatMin,
-                            xmax: o.result.properties.LonMax,
-                            ymax: o.result.properties.LatMax,
-                            spatialReference: {"wkid":4326}
-                        }),
-                        true
-                    );
-                } else {
-                    //map.setCenter();
-                    require( ["esri/geometry/Point"], function(Point) {
-                        map.centerAndZoom(
-                            new Point( o.result.properties.Lon, o.result.properties.Lat ),
-                            12
-                        );
-                        $('#geosearchModal').modal('hide');
-                    });
-                }
+				// zoom to location
+				require(["esri/geometry/Extent"], function(Extent) {
+					var noExtents = ["GNIS_MAJOR", "GNIS_MINOR", "ZIPCODE", "AREACODE"];
+					var noExtentCheck = noExtents.indexOf(o.result.properties["Source"])
+					if (noExtentCheck == -1) {
+						map.setExtent(
+							new esri.geometry.Extent({
+								xmin: o.result.properties.LonMin,
+								ymin: o.result.properties.LatMin,
+								xmax: o.result.properties.LonMax,
+								ymax: o.result.properties.LatMax,
+								spatialReference: {"wkid":4326}
+							}),
+							true
+						);
+					} else {
+						//map.setCenter();
+						require( ["esri/geometry/Point"], function(Point) {
+							map.centerAndZoom(
+								new Point( o.result.properties.Lon, o.result.properties.Lat ),
+								12
+							);
+							$('#geosearchModal').modal('hide');
+						});
+					}
 
-            });
+				});
 
-        },
-        "include_usgs_sw": true,
-        "include_usgs_gw": true,
-        "include_usgs_sp": true,
-        "include_usgs_at": true,
-        "include_usgs_ot": true,
-        "include_huc2": true,
-        "include_huc4": true,
-        "include_huc6": true,
-        "include_huc8": true,
-        "include_huc10": true,
-        "include_huc12": true
+			},
+			"include_usgs_sw": true,
+			"include_usgs_gw": true,
+			"include_usgs_sp": true,
+			"include_usgs_at": true,
+			"include_usgs_ot": true,
+			"include_huc2": true,
+			"include_huc4": true,
+			"include_huc6": true,
+			"include_huc8": true,
+			"include_huc10": true,
+			"include_huc12": true
 
-	});
+		});
+	}else{
+		// Geosearch unavailble
+		$("#geosearchUnavailable").addClass("visible");
+		$("#geosearchModalBody").addClass("hidden");
+	}
 
 
 	

--- a/src/styles/less/misc.less
+++ b/src/styles/less/misc.less
@@ -2207,3 +2207,10 @@ input[type=range] {
 	background: #0d0d0d;
   }
   
+
+  #geosearchUnavailable{
+	color: red;
+	text-align: center;
+	box-sizing: border-box;
+	padding: 25px 25px 40px 25px;
+  }

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -1936,6 +1936,12 @@ input[type=range]:focus::-ms-fill-lower {
 input[type=range]:focus::-ms-fill-upper {
   background: #0d0d0d;
 }
+#geosearchUnavailable {
+  color: red;
+  text-align: center;
+  box-sizing: border-box;
+  padding: 25px 25px 40px 25px;
+}
 #floodToolsDiv {
   box-shadow: 0px 6px 27px -7px rgba(0, 10, 80, 0.55);
   height: fit-content !important;


### PR DESCRIPTION
Just checks to see if search_api is undefined. If it is, it shows a message that it's unavailable but the app continues to load.